### PR TITLE
adding toctree using doctrees

### DIFF
--- a/jupyter_book/__init__.py
+++ b/jupyter_book/__init__.py
@@ -10,7 +10,7 @@ __version__ = "0.0.1dev0"
 # We connect this function to the step after the builder is initialized
 def setup(app):
     app.connect("config-inited", update_indexname)
-    app.connect("source-read", add_toctree)
+    app.connect("doctree-read", add_toctree)
 
     app.add_config_value("globaltoc_path", "toc.yml", "env")
 

--- a/jupyter_book/sphinx.py
+++ b/jupyter_book/sphinx.py
@@ -93,7 +93,7 @@ def build_sphinx(
 
     # Doctrees directory
     if not doctreedir:
-        doctreedir = op.join(outputdir, ".doctrees")
+        doctreedir = str(Path(outputdir).parent.joinpath(".doctrees"))
 
     if jobs is None:
         jobs = 1


### PR DESCRIPTION
This is an attempt at adding the toctree at the *doctree* level rather than at the page source level.

The doctrees do seem to be inserted properly, but for some reason Sphinx is still saying that it doesn't find the pages that are referenced in the doctrees...I need to debug this

Should look into what Sphinx is doing here: https://github.com/sphinx-doc/sphinx/blob/82d49bafc50835f4934f05567977d31f029c53de/sphinx/environment/__init__.py#L552