### PR TITLE
adding single PDF option

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,17 +12,39 @@ jobs:
           keys:
             - cache-pip
 
-      - run: pip install --user .[testing]
+      - run: pip install --user .[testing,pdf_html]
       - save_cache:
           key: cache-pip
           paths:
             - ~/.cache/pip
+
+      - run:
+          name: Install Headless Chrome dependencies
+          command: |
+            sudo apt-get install -yq \
+            gconf-service libasound2 libatk1.0-0 libatk-bridge2.0-0 libc6 libcairo2 libcups2 libdbus-1-3 \
+            libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 \
+            libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 \
+            libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates \
+            fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget
+
+      - run:
+          name: Install chromium
+          command: pyppeteer-install
 
       # Run the docs so they are up-to-date
       - run:
           name: Running tests
           command: pytest
 
+      # Build a PDF of the book to view as an artifact
+      - run:
+          name: PDF from HTML
+          command: jb build docs --build pdf_html
+
+      - store_artifacts:
+          path: docs/_build/pdf/book.pdf
+          destination: pdf
 workflows:
   version: 2
   default:

--- a/docs/start/03_build.md
+++ b/docs/start/03_build.md
@@ -1,9 +1,12 @@
-# Build HTML for your book
+# Build your book
 
 Once you've added content and configured your book, it's time to
-build the HTML for each **page** of your book. We'll use the
-`jupyter-book build` command-line tool for this. In the _next step_,
-we'll stitch these HTML pages into a book.
+build outputs for your book. We'll use the
+`jupyter-book build` command-line tool for this.
+
+Currently, there are two kinds of supported outputs: an HTML website for your
+book, and a PDF that contains all of the pages of your book that is built
+from the book HTML.
 
 ## Prerequisites
 
@@ -33,6 +36,35 @@ web browser.
 ```{note}
 You can also use the short-hand `jb` for `jupyter-book`. E.g.,:
 `jb build mybookname/`.
+```
+
+## Build a PDF from your book HTML
+
+It is also possible to build a single PDF from your book's HTML. This first
+converts all of your book's content into a single HTML file, and then renders
+it as a PDF by emulating a browser from the command-line.
+
+```{warning}
+This is an experimental feature, and may change in the future.
+```
+
+````{sidebar} **Note**
+If you wish to build a PDF from your book's HTML, you will need the `pyppeteer` package.
+You can install it like so:
+
+```
+pip install pyppeteer
+```
+
+In addition, if you get errors about libraries that don't exist, check out
+[these install commands](https://circleci.com/orbs/registry/orb/threetreeslight/puppeteer)
+to see if that fixes it. We warned you it was an experimental feature :-)
+````
+
+To build a single PDF from your book's HTML, use the following command:
+
+```
+jupyter-book build mybookname/ --build pdf_html
 ```
 
 ## Page caching

--- a/jupyter_book/pdf.py
+++ b/jupyter_book/pdf.py
@@ -1,0 +1,42 @@
+"""Commands to facilitate conversion to PDF."""
+from pathlib import Path
+import asyncio
+
+
+def html_to_pdf(html_file, pdf_file):
+    """
+    Convert arbitrary HTML file to PDF using pyppeteer.
+
+    Parameters
+    ----------
+    html_file : str
+        A path to an HTML file to convert to PDF
+    pdf_file : str
+        A path to an output PDF file that will be created
+    """
+    asyncio.get_event_loop().run_until_complete(_html_to_pdf(html_file, pdf_file))
+
+
+async def _html_to_pdf(html_file, pdf_file):
+    try:
+        from pyppeteer import launch
+    except ImportError:
+        raise ImportError(
+            (
+                "Generating PDF from book HTML requires the pyppetteer package."
+                "Install it first."
+            )
+        )
+    browser = await launch(args=["--no-sandbox"])
+    page = await browser.newPage()
+
+    # Absolute path is needed
+    html_file = Path(html_file).resolve()
+
+    # Waiting for networkidle0 seems to let mathjax render
+    await page.goto(f"file:///{html_file}", {"waitUntil": ["networkidle0"]})
+    # Give it *some* margins to make it look a little prettier
+    # I just made these up
+    page_margins = {"left": "0in", "right": "0in", "top": ".5in", "bottom": ".5in"}
+    await page.pdf({"path": pdf_file, "margin": page_margins})
+    await browser.close()

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ setup(
             "matplotlib",
             "numpy",
         ],
+        "pdf_html": "pyppeteer",
     },
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
This adds the ability to print a *single pdf* from your entire book by using `pyppeteer` (thx @yuvipanda for the original inspiration in nbpdfexport :-) )

It should be treated as experimental, but this could be a really nice way to get a good-enough PDF output that looks very similar to the HTML book site.

You invoke it by running:

```
jupyter-book build mybookname/ --build pdf_html
```

Maybe @mmcky or @jstac would think this is cool? It's not a latex replacement but still a nice option for folks that want something that looks like the HTML.