### PR TITLE
adding better logic around excluding files

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -7,6 +7,7 @@ email: choldgraf@berkeley.edu
 description: >- # this means to ignore newlines until "baseurl:"
   This is an example book built with Jupyter Books.
 execute_notebooks: cache
+
 html:
   favicon: images/favicon.ico
   google_analytics_id: UA-52617120-7

--- a/jupyter_book/default_config.yml
+++ b/jupyter_book/default_config.yml
@@ -5,19 +5,19 @@
 
 #######################################################################################
 # Book settings
-title                       : My Jupyter Book
-author                      : The Jupyter Book community,
-copyright                   : 2020,
-logo                        : ""
-exclude_files               : []
-execute_notebooks           : auto
+title                       : My Jupyter Book  # The title of the book. Will be placed in the sidebar.
+author                      : The Jupyter Book community,  # The author of the book
+copyright                   : 2020,  # Copyright year to be placed in the footer
+logo                        : ""  # A path to the book logo
+exclude_patterns               : []  # Patterns to skip when building the book. Can be glob-style (e.g. "*skip.ipynb")
+execute_notebooks           : auto  # Whether to execute notebooks at build time. Must be one of ("auto", "force", "cache", "off")
 
 #######################################################################################
 # HTML-specific settings
 html:
-  favicon                   : ""
-  sidebar_footer_text       : 'Powered by <a href="https://jupyterbook.org">Jupyter Book</a>'
-  google_analytics_id       : "" 
+  favicon                   : ""  # A path to a favicon image
+  sidebar_footer_text       : 'Powered by <a href="https://jupyterbook.org">Jupyter Book</a>'  # Will be displayed underneath the sidebar.
+  google_analytics_id       : ""  # A GA id that can be used to track book views.
 
 
 #######################################################################################
@@ -31,7 +31,7 @@ repository:
   url                       : https://github.com/ExecutableBookProject/cli  # The URL to your book's repository
   path_to_book              : ""  # A path to your book's folder, relative to the repository root.
 
-thebelab:  
+thebelab:    # NOT YET IMPLEMENTED
   use_cell_buttons          : false
   use_page_button           : false
   thebelab_button_text      : "Thebelab"  # The text to display inside the Thebelab initialization button

--- a/jupyter_book/toc.py
+++ b/jupyter_book/toc.py
@@ -3,8 +3,11 @@ import os
 import yaml
 from textwrap import dedent
 from pathlib import Path
+from sphinx.util import logging
 
 from .utils import _filename_to_title, SUPPORTED_FILE_SUFFIXES
+
+logger = logging.getLogger(__name__)
 
 
 def _no_suffix(path):
@@ -44,11 +47,12 @@ def add_toctree(app, docname, source):
     toc = app.config["globaltoc"]
     page = find_name(toc, _no_suffix(path))
 
-    # If we didn't find this page in the TOC, raise an error
+    # If we didn't find this page in the TOC, raise a warning
     if page is None:
-        raise FileNotFoundError(
-            f"The following content page exists, but is not in your table of contents:\n\n{path}.\n\nDouble check your `_toc.yml` file to make sure the paths are correct."
+        logger.warning(
+            f"Found a content page that is not in Table of Contents: {path}."
         )
+        return
 
     # If we have no sections, then don't worry about a toctree
     pages = page.get("pages")


### PR DESCRIPTION
* Files that are present but not in the TOC no longer error, but instead raise a warning
* You can exclude files in `_config.yml` with `exclude_patterns`

closes https://github.com/ExecutableBookProject/cli/issues/45