### PR TITLE
Added mini example to docs

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -10,7 +10,7 @@ Jupyter Book 2.0 allows users to
     * a publication-quality PDF.
 
 ```{warning}
-This is an early prototype that may evolve quickly. All [feedback](https://jupyter-cache.readthedocs.io/en/latest/) is very welcome! 
+This is an early prototype that may evolve quickly. All [feedback](https://jupyter-cache.readthedocs.io/en/latest/) is very welcome!
 ```
 
 
@@ -35,7 +35,7 @@ in the [docs](https://github.com/ExecutableBookProject/quantecon-mini-example/tr
 The MyST source files can be edited as either text files or Jupyter notebooks,
 or a combination of both, via [Jupytext](https://jupytext.readthedocs.io/en/latest/introduction.html)
 
-Note that 
+Note that
 
 * Jupytext [supports](https://jupytext.readthedocs.io/en/latest/formats.html#myst-markdown) the Myst markdown format.
 
@@ -52,7 +52,7 @@ You can build this book locally on the command line via the following steps:
     conda install numpy matplotlib
     ```
 
-3. Install Jupyter Book 
+3. Install Jupyter Book
 
     ```
     pip install git+https://github.com/ExecutableBookProject/cli.git@master
@@ -71,18 +71,34 @@ You can build this book locally on the command line via the following steps:
     jupyter-book build mini_book/docs
     ```
 
-6. View the result (using firefox in this example)
+6. View the result through a browser --- try (with, say, firefox)
 
 
     ```
     firefox mini_book/docs/_build/html/index.html
     ```
 
+    or
+
+    ```
+    cd mini_book/docs/_build/html
+    python -m http.server
+    ```
+
+    and point your browser at the indicated port (e.g., ``localhost:8000``).
+
 Now you might like to try editing the files in ``mini_book/docs`` and then
 rebuilding.
 
+### Further Reading
+
+See [here](https://executablebookproject.github.io/quantecon-example/docs/index.html)
+for a longer Jupyter Book 2.0 use case, drawn from the same source material.
+
 The remaining documentation provides more information on installation, use and
 features of Jupyter Book 2.0.
+
+
 
 ## The components of Jupyter Book 2.0
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -1,9 +1,8 @@
-# Books with Jupyter 2.0
+# Books with Jupyter
 
-Jupyter Book is an open-source tool for building publication-quality books and documents from
-computational material.
+Jupyter Book is an open-source tool for building publication-quality books and documents from computational material.
 
-Jupyter Book 2.0 allows users to
+Jupyter Book allows users to
 
 * write their content in [markdown files](https://myst-parser.readthedocs.io/en/latest/) or [Jupyter](https://jupyter.org/) notebooks,
 * include computational elements (e.g., code cells) in either type,
@@ -19,8 +18,7 @@ This is an early prototype that may evolve quickly. All [feedback](https://githu
 
 ## A Small Example Project
 
-[Here's](https://executablebookproject.github.io/quantecon-mini-example/docs/index.html)
-short example of a web-based book created by Jupyter Book 2.0.
+Here's [a short example](https://executablebookproject.github.io/quantecon-mini-example/docs/index.html) of a web-based book created by Jupyter Book.
 
 Some of the features on display include
 
@@ -29,16 +27,13 @@ Some of the features on display include
 * [numbered equations](https://executablebookproject.github.io/quantecon-mini-example/docs/python_by_example.html#another-application)
 * [numbered figures](https://executablebookproject.github.io/quantecon-mini-example/docs/getting_started.html#jupyter-notebooks) with captions and cross-referencing
 
-The source files are written in [MyST markdown](https://myst-parser.readthedocs.io/en/latest/) and can be [found
-on GitHub](https://github.com/ExecutableBookProject/quantecon-mini-example/)
-in the [docs directory](https://github.com/ExecutableBookProject/quantecon-mini-example/tree/master/mini_book/docs).
+The source files  can be [found on GitHub](https://github.com/ExecutableBookProject/quantecon-mini-example/) in the [docs directory](https://github.com/ExecutableBookProject/quantecon-mini-example/tree/master/mini_book/docs).
 
-```{margin}
-They could alternatively have been written directly as Jupyter notebooks!
-```
+These files are written [MyST markdown](https://myst-parser.readthedocs.io/en/latest/), an extension of Jupyter notebook markdown that allows for additional scientific markup (e.g., numbered equations).
 
-The MyST source files can be edited as either text files or Jupyter notebooks,
-or a combination of both, via [Jupytext](https://jupytext.readthedocs.io/en/latest/introduction.html)
+They could alternatively have been written directly as Jupyter notebooks.
+
+In fact the MyST source files can be edited as either text files or Jupyter notebooks,  via [Jupytext](https://jupytext.readthedocs.io/en/latest/introduction.html).
 
 Note that
 
@@ -98,16 +93,16 @@ rebuilding.
 ### Further Reading
 
 See [here](https://executablebookproject.github.io/quantecon-example/docs/index.html)
-for a longer Jupyter Book 2.0 use case, drawn from the same source material.
+for a longer Jupyter Book use case, drawn from the same source material.
 
 The remaining documentation provides more information on installation, use and
-features of Jupyter Book 2.0.
+features of Jupyter Book.
 
 
 
-## The components of Jupyter Book 2.0
+## The components of Jupyter Book
 
-Jupyter Book 2.0 is a wrapper around a collection of tools in the Python
+Jupyter Book is a wrapper around a collection of tools in the Python
 ecosystem that make it easier to publish computational documents. Here are
 a few key pieces:
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -41,6 +41,7 @@ Note that
 
 * If editing the markdown files using VS Code, the [MyST markdown extension](https://marketplace.visualstudio.com/items?itemName=ExecutableBookProject.myst-highlight) provides syntax highlighting and other features.
 
+## Build the demo book
 
 You can build this book locally on the command line via the following steps:
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -1,5 +1,8 @@
 # Books with Jupyter 2.0
 
+Jupyter Book is an open-source tool for building publication-quality books and documents from
+computational material.
+
 Jupyter Book 2.0 allows users to
 
 * write their content in [markdown files](https://myst-parser.readthedocs.io/en/latest/) or [Jupyter](https://jupyter.org/) notebooks,

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -26,18 +26,18 @@ Some of the features on display include
 * [numbered equations](https://executablebookproject.github.io/quantecon-mini-example/docs/python_by_example.html#another-application)
 * [numbered figures](https://executablebookproject.github.io/quantecon-mini-example/docs/getting_started.html#jupyter-notebooks) with captions and cross-referencing
 
-The source files are written in [Myst markdown](https://myst-parser.readthedocs.io/en/latest/) and can be [found
+The source files are written in [MyST markdown](https://myst-parser.readthedocs.io/en/latest/) and can be [found
 on GitHub](https://github.com/ExecutableBookProject/quantecon-mini-example/)
 in the [docs](https://github.com/ExecutableBookProject/quantecon-mini-example/tree/master/mini_book/docs) directory.
 
-(The could alternatively have been written directly as Jupyter notebooks.)
+(They could alternatively have been written directly as Jupyter notebooks.)
 
 The MyST source files can be edited as either text files or Jupyter notebooks,
 or a combination of both, via [Jupytext](https://jupytext.readthedocs.io/en/latest/introduction.html)
 
 Note that
 
-* Jupytext [supports](https://jupytext.readthedocs.io/en/latest/formats.html#myst-markdown) the Myst markdown format.
+* Jupytext [supports](https://jupytext.readthedocs.io/en/latest/formats.html#myst-markdown) the MyST markdown format.
 
 * If editing the markdown files using VS Code, the [MyST markdown extension](https://marketplace.visualstudio.com/items?itemName=ExecutableBookProject.myst-highlight) provides syntax highlighting and other features.
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -1,21 +1,88 @@
 # Books with Jupyter 2.0
 
-This tool provides a command-line interface and a Python API that lets users
-do the following:
+Jupyter Book 2.0 allows users to
 
-* Write their content in markdown files or Jupyter Notebooks.
-* Include computational elements in any of the above (e.g. executable
-  code cells along with their outputs)
-* Include rich syntax for publication features, such as citations,
-  cross-references, and equations.
-* Using a simple command, convert this content into:
-    * A web-based interactive book
-    * A publication-quality PDF
+* write their content in [markdown files](https://myst-parser.readthedocs.io/en/latest/) or [Jupyter](https://jupyter.org/) notebooks,
+* include computational elements (e.g., code cells) in either type,
+* include rich syntax such as citations, cross-references, and numbered equations, and
+* using a simple command, run the embedded code cells, [cache](https://jupyter-cache.readthedocs.io/en/latest/) the outputs and convert this content into:
+    * a web-based interactive book and
+    * a publication-quality PDF.
 
 ```{warning}
-This is an early prototype tool that may evolve quickly. Your feedback is
-very welcome! To give it, please [open an issue](https://github.com/ExecutableBookProject/cli/issues/new)
+This is an early prototype that may evolve quickly. All [feedback](https://jupyter-cache.readthedocs.io/en/latest/) is very welcome! 
 ```
+
+
+## A Small Example Project
+
+[Here's](https://executablebookproject.github.io/quantecon-mini-example/docs/index.html)
+short example of a web-based book created by Jupyter Book 2.0.
+
+Some of the features on display include
+
+* [Jupyter notebook-style inputs and outputs](https://executablebookproject.github.io/quantecon-mini-example/docs/python_by_example.html#version-1)
+* [citations](https://executablebookproject.github.io/quantecon-mini-example/docs/about_py.html#bibliography)
+* [numbered equations](https://executablebookproject.github.io/quantecon-mini-example/docs/python_by_example.html#another-application)
+* [numbered figures](https://executablebookproject.github.io/quantecon-mini-example/docs/getting_started.html#jupyter-notebooks) with captions and cross-referencing
+
+The source files are written in [Myst markdown](https://myst-parser.readthedocs.io/en/latest/) and can be [found
+on GitHub](https://github.com/ExecutableBookProject/quantecon-mini-example/)
+in the [docs](https://github.com/ExecutableBookProject/quantecon-mini-example/tree/master/mini_book/docs) directory.
+
+(The could alternatively have been written directly as Jupyter notebooks.)
+
+The MyST source files can be edited as either text files or Jupyter notebooks,
+or a combination of both, via [Jupytext](https://jupytext.readthedocs.io/en/latest/introduction.html)
+
+Note that 
+
+* Jupytext [supports](https://jupytext.readthedocs.io/en/latest/formats.html#myst-markdown) the Myst markdown format.
+
+* If editing the markdown files using VS Code, the [MyST markdown extension](https://marketplace.visualstudio.com/items?itemName=ExecutableBookProject.myst-highlight) provides syntax highlighting and other features.
+
+
+You can build this book locally on the command line via the following steps:
+
+1. Ensure you have a recent version of [Anaconda Python](https://www.anaconda.com/distribution/) installed.
+
+2. Install the Python libraries needed to run the code in this particular example:
+
+    ```
+    conda install numpy matplotlib
+    ```
+
+3. Install Jupyter Book 
+
+    ```
+    pip install git+https://github.com/ExecutableBookProject/cli.git@master
+    ```
+
+4. Clone the repository containing the source files
+
+    ```
+    git clone https://github.com/ExecutableBookProject/quantecon-mini-example
+    ```
+
+5. Run Jupyter Book over the source files
+
+    ```
+    cd quantecon-mini-example
+    jupyter-book build mini_book/docs
+    ```
+
+6. View the result (using firefox in this example)
+
+
+    ```
+    firefox mini_book/docs/_build/html/index.html
+    ```
+
+Now you might like to try editing the files in ``mini_book/docs`` and then
+rebuilding.
+
+The remaining documentation provides more information on installation, use and
+features of Jupyter Book 2.0.
 
 ## The components of Jupyter Book 2.0
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -31,7 +31,7 @@ Some of the features on display include
 
 The source files are written in [MyST markdown](https://myst-parser.readthedocs.io/en/latest/) and can be [found
 on GitHub](https://github.com/ExecutableBookProject/quantecon-mini-example/)
-in the [docs](https://github.com/ExecutableBookProject/quantecon-mini-example/tree/master/mini_book/docs) directory.
+in the [docs directory](https://github.com/ExecutableBookProject/quantecon-mini-example/tree/master/mini_book/docs).
 
 (They could alternatively have been written directly as Jupyter notebooks.)
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -29,7 +29,9 @@ Some of the features on display include
 
 The source files  can be [found on GitHub](https://github.com/ExecutableBookProject/quantecon-mini-example/) in the [docs directory](https://github.com/ExecutableBookProject/quantecon-mini-example/tree/master/mini_book/docs).
 
-These files are written [MyST markdown](https://myst-parser.readthedocs.io/en/latest/), an extension of Jupyter notebook markdown that allows for additional scientific markup (e.g., numbered equations).
+These files are written in [MyST markdown](https://myst-parser.readthedocs.io/en/latest/), an
+extension of Jupyter notebook markdown that allows for
+additional scientific markup (e.g., numbered equations).
 
 They could alternatively have been written directly as Jupyter notebooks.
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -33,7 +33,9 @@ The source files are written in [MyST markdown](https://myst-parser.readthedocs.
 on GitHub](https://github.com/ExecutableBookProject/quantecon-mini-example/)
 in the [docs directory](https://github.com/ExecutableBookProject/quantecon-mini-example/tree/master/mini_book/docs).
 
-(They could alternatively have been written directly as Jupyter notebooks.)
+```{margin}
+They could alternatively have been written directly as Jupyter notebooks!
+```
 
 The MyST source files can be edited as either text files or Jupyter notebooks,
 or a combination of both, via [Jupytext](https://jupytext.readthedocs.io/en/latest/introduction.html)

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -10,7 +10,7 @@ Jupyter Book 2.0 allows users to
     * a publication-quality PDF.
 
 ```{warning}
-This is an early prototype that may evolve quickly. All [feedback](https://jupyter-cache.readthedocs.io/en/latest/) is very welcome!
+This is an early prototype that may evolve quickly. All [feedback](https://github.com/ExecutableBookProject/cli/issues/new) is very welcome!
 ```
 
 


### PR DESCRIPTION
Updates docs as per the discussion in https://github.com/ExecutableBookProject/meta/issues/46.

* Small edits to first few lines of the docs to slim down sentences and add a few links.

* Added discussion of quantecon-mini-example and how to build / edit / view it locally.